### PR TITLE
Add menu cards and celebratory training messages

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,39 +18,54 @@
             height: 100vh;
         }
         .menu {
-            max-width: 400px;
+            display: flex;
+            gap: 20px;
+        }
+        .card {
+            flex: 1;
+            max-width: 350px;
             background-color: rgba(51, 51, 51, 0.85);
             padding: 30px;
             border-radius: 15px;
             box-shadow: 0 8px 25px rgba(0, 0, 0, 0.4);
             text-align: center;
         }
-        h1 {
+        .card h2 {
             color: #00BCD4;
-            margin-bottom: 30px;
-            font-size: 28px;
+            margin-bottom: 15px;
+            font-size: 24px;
         }
-        a {
-            display: block;
+        .card p {
+            margin-bottom: 20px;
+            line-height: 1.4;
+        }
+        .card a {
+            display: inline-block;
             background-color: #00BCD4;
             color: white;
             text-decoration: none;
-            padding: 15px;
+            padding: 12px 20px;
             font-size: 18px;
             border-radius: 8px;
-            margin-bottom: 20px;
             transition: background-color 0.3s ease;
         }
-        a:hover {
+        .card a:hover {
             background-color: #0097a7;
         }
     </style>
 </head>
 <body>
     <div class="menu">
-        <h1>Choose Mode</h1>
-        <a href="calculator.html">Calculator</a>
-        <a href="training.html">Training</a>
+        <div class="card">
+            <h2>Калькулятор ID</h2>
+            <p>Вычисляй параметры подсети для любого IP/CIDR.</p>
+            <a href="calculator.html">Открыть</a>
+        </div>
+        <div class="card">
+            <h2>Тест знаний</h2>
+            <p>Попробуй сам проверить свои знания. Возьми листик бумаги и ручку и посчитай.</p>
+            <a href="training.html">Начать</a>
+        </div>
     </div>
 </body>
 </html>

--- a/training.html
+++ b/training.html
@@ -66,6 +66,13 @@
             color: #00BCD4;
             font-weight: bold;
         }
+        #congrats {
+            text-align: center;
+            margin-top: 10px;
+            font-size: 20px;
+            display: none;
+            color: #00BCD4;
+        }
     </style>
 </head>
 <body>
@@ -84,6 +91,7 @@
         <input type="text" id="step5" placeholder="192.168.0.1 - 192.168.0.254">
         <button onclick="checkAnswers()">Check Answers</button>
         <button onclick="generateChallenge()">New IP</button>
+        <div id="congrats" class="highlight"></div>
     </div>
     <script src="training.js"></script>
 </body>

--- a/training.js
+++ b/training.js
@@ -28,9 +28,13 @@ function generateChallenge() {
         input.value = '';
         input.style.borderColor = '#00BCD4';
     }
+    const message = document.getElementById('congrats');
+    message.style.display = 'none';
+    message.innerText = '';
 }
 
 function checkAnswers() {
+    let allCorrect = true;
     for (let i = 1; i <= 5; i++) {
         const input = document.getElementById(`step${i}`);
         const value = input.value.trim();
@@ -38,7 +42,66 @@ function checkAnswers() {
             input.style.borderColor = 'green';
         } else {
             input.style.borderColor = 'red';
+            allCorrect = false;
         }
+    }
+    if (allCorrect) {
+        const messages = [
+            "Ты молодец!",
+            "Ты крутой!",
+            "У тебя все получится!",
+            "Так держать!",
+            "Отличная работа!",
+            "Ты просто гений!",
+            "Невероятно!",
+            "Ты на правильном пути!",
+            "Ты сделал это!",
+            "Браво!",
+            "Фантастический результат!",
+            "Ты настоящий профи!",
+            "Уже мастерство!",
+            "У тебя золотой мозг!",
+            "Превосходно!",
+            "Умничка!",
+            "Потрясающе!",
+            "Ты лучший!",
+            "Великолепно!",
+            "Супер!",
+            "Так и продолжай!",
+            "Ты достиг цели!",
+            "Твой прогресс впечатляет!",
+            "Ты на высоте!",
+            "Заслуженный успех!",
+            "Это было блестяще!",
+            "Талантливо!",
+            "Достойно аплодисментов!",
+            "Твоя настойчивость окупилась!",
+            "Ты растешь с каждым шагом!",
+            "С каждым разом всё лучше!",
+            "Победа за тобой!",
+            "Горжусь тобой!",
+            "Смело и точно!",
+            "Великолепная работа!",
+            "Талант видно сразу!",
+            "Нельзя не восхититься!",
+            "У тебя железная логика!",
+            "Потрясающее мышление!",
+            "Ты почти хакер!",
+            "Ты пример для остальных!",
+            "Вдохновляешь!",
+            "Этот успех заслужен!",
+            "Ты отлично постарался!",
+            "Отличный подход!",
+            "Ты превосходишь ожидания!",
+            "Такого результата не каждый добьется!",
+            "Твой мозг сверкает!",
+            "Блестяще выполнено!",
+            "Ты полностью справился!"
+        ];
+        const randomMessage = messages[Math.floor(Math.random() * messages.length)];
+        const messageElement = document.getElementById('congrats');
+        messageElement.innerText = randomMessage;
+        messageElement.style.display = 'block';
     }
 }
 


### PR DESCRIPTION
## Summary
- Replace basic links with two menu cards for calculator and training modes
- Show a random congratulations in training mode when all answers are correct

## Testing
- `node --check training.js`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e865dc1888323af75fe68dd36a58d